### PR TITLE
paper-snowflake-top: Make the header slimmer and more prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bower_components/
 node_modules/
 theme_components/cover.jpg
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # theme-paper-snowflake
 Snowflake's Material Design theme
+![screen0](http://i.imgur.com/nKHUOHa.png)
 ![screen1](http://i.imgur.com/dUbZSk1.png)
-![screen2](https://a.pomf.se/xpsebx.png)

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
     "core-elements": "Polymer/core-elements#^0.5.5",
     "paper-elements": "Polymer/paper-elements#^0.5.5",
     "color-thief": "*",
-    "fuse": "~1.2.2"
+    "fuse": "~1.2.2",
+    "material-design-iconic-font": "~2.1.2"
   },
   "resolutions": {
     "webcomponentsjs": "^0.6.0"

--- a/theme_components/paper-snowflake-main.html
+++ b/theme_components/paper-snowflake-main.html
@@ -1,6 +1,8 @@
 <link rel="import" href="paper-snowflake-state">
 
 <link rel="import" href="paper-snowflake-top">
+<link rel="import" href="paper-snowflake-windowchrome">
+
 <link rel="import" href="paper-snowflake-platform-selector">
 <link rel="import" href="paper-snowflake-port-selector">
 <link rel="import" href="paper-fonts">
@@ -37,6 +39,7 @@
       paper-snowflake-top {
         height: 60px;
       }
+
       .select-main {
         height: inherit;
         display: table;
@@ -128,6 +131,7 @@
     ></paper-snowflake-state>
     <fuse-provider inputArray="{{selectedPlatformGames}}" searchQuery="{{searchQuery}}" searchKeys="{{searchKeys}}" outputArray="{{availableGames}}"></fuse-provider>
     <paper-snowflake-game-details on-notify-message="{{messagePopup}}" unresolved id="detailsView" coverUrl="{{coverFrontUrl}}" selectedGame="{{selectedGame}}"></paper-snowflake-game-details>
+    <paper-snowflake-windowchrome></paper-snowflake-windowchrome>
     <paper-snowflake-top id="topbar" titleText="{{titleText}}" on-switch-page-requested="{{switchPage}}" unresolved selectedPlatform="{{selectedPlatform}}" searchQuery="{{searchQuery}}"></paper-snowflake-top>
     <core-animated-pages on-core-select="{{pageChanged}}" id="pageContainer" class="main-container" transitions="slide-from-right">
 

--- a/theme_components/paper-snowflake-main.html
+++ b/theme_components/paper-snowflake-main.html
@@ -135,7 +135,7 @@
     <paper-snowflake-top id="topbar" titleText="{{titleText}}" on-switch-page-requested="{{switchPage}}" unresolved selectedPlatform="{{selectedPlatform}}" searchQuery="{{searchQuery}}"></paper-snowflake-top>
     <core-animated-pages on-core-select="{{pageChanged}}" id="pageContainer" class="main-container" transitions="slide-from-right">
 
-      <section unresolved class="select-main">
+      <section unresolved on-keydown="{{focusSearch}}" class="select-main">
         <paper-snowflake-platform-selector selectedPlatform="{{selectedPlatform}}" availablePlatforms="{{availablePlatforms}}"></paper-snowflake-platform-selector>
         <paper-snowflake-games-container on-game-show="{{gameShow}}" selectedGame="{{selectedGame}}" selectedPlatform="{{selectedPlatform}}" selectedPlatformGames="{{availableGames}}"></paper-snowflake-games-container>
       </section>
@@ -192,6 +192,13 @@
       },
       addGame: function(e) {
         this.$.addGameDialog.open();
+      },
+      focusSearch: function(){
+        this.fire('switch-page-requested', {"selected": 0});
+        this.$.topbar.$.gameSearch.focus();
+        var rect = this.$.topbar.$.gameSearch.getBoundingClientRect()
+        this.$.topbar.$.ripple.downAction({x: rect.left, y: rect.bottom});
+        this.$.topbar.$.ripple.upAction();
       },
       selectedGameChanged: function() {
         this.coverFrontUrl = "http://localhost:30002/"+this.selectedGame.UUID+"/BoxartFront";

--- a/theme_components/paper-snowflake-main.html
+++ b/theme_components/paper-snowflake-main.html
@@ -35,7 +35,7 @@
         z-index: 1000000000000000;
       }
       paper-snowflake-top {
-        height: 100px;
+        height: 60px;
       }
       .select-main {
         height: inherit;
@@ -45,11 +45,11 @@
         height: 100%;
       }
       .settings-selector, .main-container {
-        height: calc(100vh - 100px);
+        height: calc(100vh - 60px);
         width: 100%;
       }
       .settings-selector > * {
-        height: calc(100vh - 100px);
+        height: calc(100vh - 60px);
       }
       paper-snowflake-abstraction-controller {
         margin: 0 10px;
@@ -75,7 +75,7 @@
         content: "";
         z-index: 1000;
         pointer-events: none;
-        height: 100px;
+        height:60px;
         width: 100vw;
         margin-left: 307px;
         box-shadow: 0px 1px 5px rgba(0,0,0,0.3);

--- a/theme_components/paper-snowflake-top.html
+++ b/theme_components/paper-snowflake-top.html
@@ -10,13 +10,15 @@
           <div>SNOWFLAKE</div>
         </span>
         <div id="search" class="header-cell">
+          <div class="buttons fix-7px-height inputsearch">
+            <paper-icon-button on-tap="{{focusInput}}" icon="search"></paper-icon-button>
+          </div>
           <paper-ripple id="ripple" fit style="pointer-events: none;"></paper-ripple>
           <div id="inputcontainer">
             <input class="input" type="text" on-focus="{{inputFocused}}" on-blur="{{inputBlur}}" on-down="{{searchTapDown}}" on-up="{{searchTapUp}}" id="gameSearch" autocomplete="off" placeholder="{{titleText}}" value="{{searchQuery}}">
             </input>
           </div>
           <div class="buttons fix-7px-height">
-            <paper-icon-button on-tap="{{focusInput}}" icon="search"></paper-icon-button>
             <paper-icon-button on-tap="{{switchPage}}" icon="{{pageicon}}"></paper-icon-button>
           </div>
         </div>

--- a/theme_components/paper-snowflake-top.html
+++ b/theme_components/paper-snowflake-top.html
@@ -6,16 +6,16 @@
     <link rel="stylesheet" type="text/css" href="style/paper-snowflake-top.css"/>
     <header class="colorheader">
       <div id="container">
-        <span id="tag" class="header-cell">
+        <span id="tag" class="header-cell fix-7px-height">
           <div>SNOWFLAKE</div>
         </span>
         <div id="search" class="header-cell">
           <paper-ripple id="ripple" fit style="pointer-events: none;"></paper-ripple>
           <div id="inputcontainer">
-            <input type="text" on-focus="{{inputFocused}}" on-blur="{{inputBlur}}" on-down="{{searchTapDown}}" on-up="{{searchTapUp}}" id="gameSearch" autocomplete="off" placeholder="{{titleText}}" value="{{searchQuery}}">
+            <input class="input" type="text" on-focus="{{inputFocused}}" on-blur="{{inputBlur}}" on-down="{{searchTapDown}}" on-up="{{searchTapUp}}" id="gameSearch" autocomplete="off" placeholder="{{titleText}}" value="{{searchQuery}}">
             </input>
           </div>
-          <div class="buttons">
+          <div class="buttons fix-7px-height">
             <paper-icon-button on-tap="{{focusInput}}" icon="search"></paper-icon-button>
             <paper-icon-button on-tap="{{switchPage}}" icon="{{pageicon}}"></paper-icon-button>
           </div>

--- a/theme_components/paper-snowflake-top.html
+++ b/theme_components/paper-snowflake-top.html
@@ -7,16 +7,19 @@
     <header class="colorheader">
       <div id="container">
         <span id="tag" class="header-cell">
-          SNOWFLAKE
+          <div>SNOWFLAKE</div>
         </span>
-        <span id="search" class="header-cell">
+        <div id="search" class="header-cell">
           <paper-ripple id="ripple" fit style="pointer-events: none;"></paper-ripple>
-          <input type="text" on-focus="{{inputFocused}}" on-blur="{{inputBlur}}" class="center" on-down="{{searchTapDown}}" on-up="{{searchTapUp}}" id="gameSearch" autocomplete="off" placeholder="{{titleText}}" value="{{searchQuery}}">
-          </input>
-          <paper-icon-button on-tap="{{focusInput}}" class="center" icon="search"></paper-icon-button>
-          <paper-icon-button on-tap="{{switchPage}}" class="center" icon="{{pageicon}}"></paper-icon-button>
-        </span>
-      <div>
+          <div id="inputcontainer">
+            <input type="text" on-focus="{{inputFocused}}" on-blur="{{inputBlur}}" on-down="{{searchTapDown}}" on-up="{{searchTapUp}}" id="gameSearch" autocomplete="off" placeholder="{{titleText}}" value="{{searchQuery}}">
+            </input>
+          </div>
+          <div class="buttons">
+            <paper-icon-button on-tap="{{focusInput}}" icon="search"></paper-icon-button>
+            <paper-icon-button on-tap="{{switchPage}}" icon="{{pageicon}}"></paper-icon-button>
+          </div>
+        </div>
     </header>
   </template>
   <script>

--- a/theme_components/paper-snowflake-top.html
+++ b/theme_components/paper-snowflake-top.html
@@ -44,7 +44,6 @@
         inputFocused: function(){
           this._titleText = this.titleText;
           this.titleText = "Search...";
-
         },
         inputBlur: function(){
           this.titleText = this._titleText;

--- a/theme_components/paper-snowflake-windowchrome.html
+++ b/theme_components/paper-snowflake-windowchrome.html
@@ -1,0 +1,43 @@
+<link rel="import" href="paper-fonts">
+<link rel="import" href="../bower_components/core-icons/av-icons">
+<link rel="stylesheet" href="../bower_components/material-design-iconic-font/dist/css/material-design-iconic-font.min.css">
+<!--
+  This provides a false windowchrome (title bar) for theme-paper-snowflake based on material design guidelines.
+  The false window chrome only works with the electron frameless window api.
+-->
+<polymer-element name="paper-snowflake-windowchrome" attributes="isMaximized">
+  <template>
+    <!--must import it twice due to import the font properly when including this htmlfile-->
+    <link rel="stylesheet" href="../bower_components/material-design-iconic-font/dist/css/material-design-iconic-font.min.css">
+    <link rel="stylesheet" href="style/paper-snowflake-windowchrome.css">
+    <header class="colorheader">
+      <div class="buttons">
+      <i class="zmdi zmdi-window-minimize" on-tap="{{windowMinimize}}"></i>
+      <i class="zmdi zmdi-window-restore" on-tap="{{windowRestore}}" hidden?="{{!isMaximizeds}}"></i>
+      <i class="zmdi zmdi-window-maximize" on-tap="{{windowMaximize}}" hidden?="{{isMaximizeds}}"></i>
+      <i class="zmdi zmdi-close" on-tap="{{windowClose}}"></i>
+    </div>
+    </header>
+  </template>
+  <script>
+       Polymer('paper-snowflake-windowchrome', {
+        ready: function() {
+
+        },
+        windowClose: function(){
+          require('remote').getCurrentWindow().close(); //electron only method
+        },
+        windowRestore: function(){
+          require('remote').getCurrentWindow().unmaximize() //electron only
+          this.isMaximized = require('remote').getCurrentWindow().isMaximized()
+        },
+        windowMaximize: function(){
+          require('remote').getCurrentWindow().maximize() //electron only
+          this.isMaximized = require('remote').getCurrentWindow().isMaximized()
+        },
+        windowMinimize: function(){
+          require('remote').getCurrentWindow().minimize(); //electron only
+        }
+      });
+  </script>
+</polymer-element>

--- a/theme_components/style/pages-selector.css
+++ b/theme_components/style/pages-selector.css
@@ -23,7 +23,7 @@
   padding: 0;
 }
 .item {
-  padding: 10px;
+  padding: 2px;
   background-color: inherit;
 }
 .item:hover {

--- a/theme_components/style/paper-snowflake-top.css
+++ b/theme_components/style/paper-snowflake-top.css
@@ -57,7 +57,8 @@
 #inputcontainer > input[type=text] {
   font-family: 'Roboto', sans-serif;
   font-weight: 100;
-  background-color: transparent;
+  background-color: rgba(255,255,255,0.2);
+  padding-right: 10px;
   border: none;
   color: inherit;
   outline: none;
@@ -67,6 +68,8 @@
   border: 1px solid transparent;
   width: 100%;
   padding-left: 10px;
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
 }
 #inputcontainer {
   width: 75%;
@@ -95,4 +98,5 @@
   align-self: center;
   alignment-baseline: central;
   line-height: initial;
+  margin-left: 20px;
 }

--- a/theme_components/style/paper-snowflake-top.css
+++ b/theme_components/style/paper-snowflake-top.css
@@ -69,7 +69,7 @@
   border: 1px solid transparent;
   width: 100%;
   padding-left: 10px;
-  border-radius: 5px;
+  border-radius: 7px;
 }
 
 #inputcontainer {

--- a/theme_components/style/paper-snowflake-top.css
+++ b/theme_components/style/paper-snowflake-top.css
@@ -5,7 +5,7 @@
 	bottom:0;
 	height: inherit;
   color: #fff;
-  font-size: 80px;
+  font-size: 40px;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
@@ -33,11 +33,12 @@
   display: table;
   bottom: 0;
   position: absolute;
-  line-height: 100px;
+  line-height: 60px;
   overflow: hidden;
   background-color: #03A9F4;
 }
 #tag {
+  display: table-cell;
   width: 308px;
   min-width: 308px;
   font-family: 'Bebas Neue', sans-serif;
@@ -45,11 +46,15 @@
   font-weight: 200;
   text-align: center;
   box-shadow: inset 0px 0px 0px 200px rgba(0,0,0,0.25);
+  vertical-align: middle;
+}
+#tag > div {
+  height: calc(60px - 7px); /*Somehow there is a discrepency of 7px even though the height provided is 60px. Subtracting 7 fixes this */
 }
 #search {
   cursor: text;
 }
-#search > input[type=text] {
+#inputcontainer > input[type=text] {
   font-family: 'Roboto', sans-serif;
   font-weight: 100;
   background-color: transparent;
@@ -57,17 +62,37 @@
   color: inherit;
   outline: none;
   font-size: 0.6em;
-  padding: 10px 0;
-  height: 60%;
-  width: 75%;
+  height: 60px;
+  line-height: 60px;
   border: 1px solid transparent;
+  width: 100%;
+  padding-left: 10px;
+}
+#inputcontainer {
+  width: 75%;
+  height: 100%;
+  display: inline-block;
+  align-items: center;
+  align-content: center;
+  align-self: center;
+  alignment-baseline: central;
 }
 
-#search > input[type=text]::-webkit-input-placeholder {
+#inputcontainer > input[type=text]::-webkit-input-placeholder {
   color: inherit;
 }
 
 .center {
   transform: translateY(-10px) translateX(20px);
 
+}
+
+.buttons {
+  height: 100%;
+  display: inline-flex;
+  align-items: center;
+  align-content: center;
+  align-self: center;
+  alignment-baseline: central;
+  line-height: initial;
 }

--- a/theme_components/style/paper-snowflake-top.css
+++ b/theme_components/style/paper-snowflake-top.css
@@ -48,13 +48,14 @@
   box-shadow: inset 0px 0px 0px 200px rgba(0,0,0,0.25);
   vertical-align: middle;
 }
-#tag > div {
-  height: calc(60px - 7px); /*Somehow there is a discrepency of 7px even though the height provided is 60px. Subtracting 7 fixes this */
+.fix-7px-height {
+  transform: translateY(3.5px);
+
 }
 #search {
   cursor: text;
 }
-#inputcontainer > input[type=text] {
+.input {
   font-family: 'Roboto', sans-serif;
   font-weight: 100;
   background-color: rgba(255,255,255,0.2);
@@ -68,9 +69,9 @@
   border: 1px solid transparent;
   width: 100%;
   padding-left: 10px;
-  border-top-right-radius: 5px;
-  border-bottom-right-radius: 5px;
+  border-radius: 5px;
 }
+
 #inputcontainer {
   width: 75%;
   height: 100%;
@@ -85,11 +86,6 @@
   color: inherit;
 }
 
-.center {
-  transform: translateY(-10px) translateX(20px);
-
-}
-
 .buttons {
   height: 100%;
   display: inline-flex;
@@ -99,4 +95,8 @@
   alignment-baseline: central;
   line-height: initial;
   margin-left: 20px;
+}
+
+.inputsearch {
+  margin-right: 10px;
 }

--- a/theme_components/style/paper-snowflake-top.css
+++ b/theme_components/style/paper-snowflake-top.css
@@ -13,6 +13,9 @@
   display: table-cell;
   position: relative;
 }
+#chrome {
+  height: 30px;
+}
 .indicator {
   font-family: 'Roboto', sans-serif;
   font-weight: 100;
@@ -69,7 +72,6 @@
   border: 1px solid transparent;
   width: 100%;
   padding-left: 10px;
-  border-radius: 7px;
 }
 
 #inputcontainer {

--- a/theme_components/style/paper-snowflake-windowchrome.css
+++ b/theme_components/style/paper-snowflake-windowchrome.css
@@ -1,0 +1,28 @@
+.buttons {
+  color: white;
+  height: inherit;
+  font-size: 20px;
+  text-align: right;
+  padding: 0 5px;
+}
+.zmdi {
+  -webkit-user-select: all;
+}
+.zmdi-window-minimize:hover {
+  color: rgb(252, 186, 76);
+}
+.zmdi-close:hover {
+  color: rgb(252, 97, 92);
+}
+.zmdi-window-maximize:hover, .zmdi-window-restore:hover {
+  color: rgb(52, 200, 73);
+}
+.colorheader{
+  box-shadow: inset 0px 0px 0px 200px rgba(0,0,0,0.5),
+              0px 1px 5px rgba(0,0,0,0.1);
+  z-index:100000000;
+  position: relative;
+  background-color: #03A9F4;
+  -webkit-app-region: drag;
+  -webkit-user-select: none;
+}


### PR DESCRIPTION
This reduces the header width from 100px to 60px for a slimmer look. It also makes a few QOL changes such as moving the search button to the left of the search/status bar, and adding paper-snowflake-windowchrome, a false windowchrome for electron's frameless window. 

![screen](http://i.imgur.com/nKHUOHa.png)
